### PR TITLE
Update to documentation mistake on readSync.

### DIFF
--- a/FuseJS/04 - APIs.md
+++ b/FuseJS/04 - APIs.md
@@ -123,7 +123,7 @@ Synchronously read data from a file in the application folder:
 
 	var data = storage.readSync("filename.txt");
 
-> Warning: This call will block, if you are writing large amounts of data, use @(Storage.read).
+> Warning: This call will block, if you are reading large amounts of data, use @(Storage.read).
 
 ### `deleteSync`
 


### PR DESCRIPTION
Using "reading" instead of writeSync's "writing" to large amount of data.